### PR TITLE
More KK_Pregnancy config options

### DIFF
--- a/KK_Pregnancy/PregnancyCharaController.cs
+++ b/KK_Pregnancy/PregnancyCharaController.cs
@@ -184,7 +184,8 @@ namespace KK_Pregnancy
             float GetInflationChange()
             {
                 //var inflationChange = Time.deltaTime / 2 + Time.deltaTime * _inflationChange / 3;
-                return Mathf.Max(0.1f * Time.deltaTime, Mathf.Abs(Time.deltaTime * _inflationChange / 4));
+                return Mathf.Max((0.1f * PregnancyPlugin.InflationSpeed.Value) * Time.deltaTime,
+                    Mathf.Abs(Time.deltaTime * (_inflationChange * PregnancyPlugin.InflationSpeed.Value) / 4));
             }
 
             if (PregnancyPlugin.InflationEnable.Value)

--- a/KK_Pregnancy/PregnancyGameController.cs
+++ b/KK_Pregnancy/PregnancyGameController.cs
@@ -55,7 +55,9 @@ namespace KK_Pregnancy
                 //Allow pregnancy if enabled, or overridden, and is not currently pregnant
                 if (!controller.Data.GameplayEnabled || controller.Data.IsPregnant) return;
 
-                var winThreshold = Mathf.RoundToInt(controller.Data.Fertility * 100);
+                var fertility = (PregnancyPlugin.FertilityOverride.Value > controller.Data.Fertility) ? PregnancyPlugin.FertilityOverride.Value : controller.Data.Fertility;
+
+                var winThreshold = Mathf.RoundToInt(fertility * 100);
                 var childLottery = Random.Range(1, 100);
                 //Logger.Log(LogLevel.Debug, $"Preg - OnEndH calc pregnancy chance {childLottery} to {winThreshold}");
                 var wonAChild = winThreshold >= childLottery;

--- a/KK_Pregnancy/PregnancyGameController.cs
+++ b/KK_Pregnancy/PregnancyGameController.cs
@@ -45,14 +45,15 @@ namespace KK_Pregnancy
             var isDangerousDay = HFlag.GetMenstruation(heroine.MenstruationDay) == HFlag.MenstruationType.危険日;
             if (!isDangerousDay) return;
 
-            var cameInside = PregnancyPlugin.ConceptionEnabled.Value && proc.flags.count.sonyuInside > 0;
+            var cameInside = (PregnancyPlugin.ConceptionEnabled.Value || PregnancyPlugin.ConceptionOverrideEnabled.Value) && proc.flags.count.sonyuInside > 0;
             var cameInsideAnal = PregnancyPlugin.AnalConceptionEnabled.Value && proc.flags.count.sonyuAnalInside > 0;
             if (cameInside || cameInsideAnal)
             {
                 var controller = heroine.chaCtrl.GetComponent<PregnancyCharaController>();
                 if (controller == null) throw new ArgumentNullException(nameof(controller));
 
-                if (!controller.Data.GameplayEnabled || controller.Data.IsPregnant) return;
+                //Allow pregnancy if enabled, or overridden, and is not currently pregnant
+                if ((!PregnancyPlugin.ConceptionOverrideEnabled.Value && !controller.Data.GameplayEnabled) || controller.Data.IsPregnant) return;
 
                 var winThreshold = Mathf.RoundToInt(controller.Data.Fertility * 100);
                 var childLottery = Random.Range(1, 100);

--- a/KK_Pregnancy/PregnancyGameController.cs
+++ b/KK_Pregnancy/PregnancyGameController.cs
@@ -45,7 +45,7 @@ namespace KK_Pregnancy
             var isDangerousDay = HFlag.GetMenstruation(heroine.MenstruationDay) == HFlag.MenstruationType.危険日;
             if (!isDangerousDay) return;
 
-            var cameInside = (PregnancyPlugin.ConceptionEnabled.Value || PregnancyPlugin.ConceptionOverrideEnabled.Value) && proc.flags.count.sonyuInside > 0;
+            var cameInside = PregnancyPlugin.ConceptionEnabled.Value && proc.flags.count.sonyuInside > 0;
             var cameInsideAnal = PregnancyPlugin.AnalConceptionEnabled.Value && proc.flags.count.sonyuAnalInside > 0;
             if (cameInside || cameInsideAnal)
             {
@@ -53,7 +53,7 @@ namespace KK_Pregnancy
                 if (controller == null) throw new ArgumentNullException(nameof(controller));
 
                 //Allow pregnancy if enabled, or overridden, and is not currently pregnant
-                if ((!PregnancyPlugin.ConceptionOverrideEnabled.Value && !controller.Data.GameplayEnabled) || controller.Data.IsPregnant) return;
+                if (!controller.Data.GameplayEnabled || controller.Data.IsPregnant) return;
 
                 var winThreshold = Mathf.RoundToInt(controller.Data.Fertility * 100);
                 var childLottery = Random.Range(1, 100);

--- a/KK_Pregnancy/PregnancyPlugin.cs
+++ b/KK_Pregnancy/PregnancyPlugin.cs
@@ -19,11 +19,13 @@ namespace KK_Pregnancy
 
         public static ConfigEntry<bool> ConceptionEnabled { get; private set; }
         public static ConfigEntry<bool> AnalConceptionEnabled { get; private set; }
+        public static ConfigEntry<bool> ConceptionOverrideEnabled { get; private set; }
         public static ConfigEntry<bool> ShowPregnancyIconEarly { get; private set; }
         public static ConfigEntry<int> PregnancyProgressionSpeed { get; private set; }
         public static ConfigEntry<bool> HSceneMenstrIconOverride { get; private set; }
 
         public static ConfigEntry<bool> InflationEnable { get; private set; }
+        public static ConfigEntry<int> InflationSpeed { get; private set; }
         public static ConfigEntry<bool> InflationOpenClothAtMax { get; private set; }
         public static ConfigEntry<int> InflationMaxCount { get; private set; }
         //public static ConfigEntry<int> InflationDrainSpeed { get; private set; }
@@ -46,6 +48,9 @@ namespace KK_Pregnancy
             AnalConceptionEnabled = Config.Bind("General", "Enable anal conception", false,
                 "Allows characters to get pregnant from anal sex. Doesn't affect already pregnant characters.");
 
+            ConceptionOverrideEnabled = Config.Bind("General", "Override conception for all", false,
+                "Allows any character to get pregnant. Even if pregnancy has not been enabled in character creater.  Doesn't affect already pregnant characters.");
+
             ShowPregnancyIconEarly = Config.Bind("General", "Show pregnancy icon early", false,
                 "By default pregnancy status icon in class roster is shown after a few days or weeks (the character had a chance to do the test or noticed something is wrong).\n" +
                 "Turning this on will always make the icon show up at the end of the current day.");
@@ -55,7 +60,13 @@ namespace KK_Pregnancy
                 "If the status is unknown you will have to listen for the voice cues instead.\nChanges take effect after game restart.");
 
             InflationEnable = Config.Bind("Inflation", "Enable inflation", true, "Turn on the inflation effect.");
+
+            InflationSpeed = Config.Bind("Inflation", "Inflation speed", 1, 
+                new ConfigDescription("How quickly the belly will inflate/deflate. \n\n1x, 2x, 3x",
+                new AcceptableValueList<int>(1, 2, 3)));
+
             InflationOpenClothAtMax = Config.Bind("Inflation", "Open clothes at max inflation", true, "If clothes are fully on, open them when inflation reaches the max value (they 'burst' open).");
+
             InflationMaxCount = Config.Bind("Inflation", "Cum count until full", 8, new ConfigDescription("How many times you have to let out inside to reach the maximum belly size.",
                 new AcceptableValueRange<int>(2, 15)));
 

--- a/KK_Pregnancy/PregnancyPlugin.cs
+++ b/KK_Pregnancy/PregnancyPlugin.cs
@@ -18,6 +18,7 @@ namespace KK_Pregnancy
         public const string Version = "2.2";
 
         public static ConfigEntry<bool> ConceptionEnabled { get; private set; }
+        public static ConfigEntry<float> FertilityOverride { get; private set; }
         public static ConfigEntry<bool> AnalConceptionEnabled { get; private set; }
         public static ConfigEntry<bool> ShowPregnancyIconEarly { get; private set; }
         public static ConfigEntry<int> PregnancyProgressionSpeed { get; private set; }
@@ -43,6 +44,11 @@ namespace KK_Pregnancy
 
             ConceptionEnabled = Config.Bind("General", "Enable conception", true,
                 "Allows characters to get pregnant from vaginal sex. Doesn't affect already pregnant characters.");
+
+            FertilityOverride = Config.Bind<float>("General", "Fertility override", 0.3f,
+                new ConfigDescription("Overrides default character fertility values with the one selected. \n\n" +
+                    "30%, 50%, 75%, 100% chance to get pregnant after HScene",
+                new AcceptableValueList<float>(0.3f, 0.5f, 0.75f, 1f)));
 
             AnalConceptionEnabled = Config.Bind("General", "Enable anal conception", false,
                 "Allows characters to get pregnant from anal sex. Doesn't affect already pregnant characters.");

--- a/KK_Pregnancy/PregnancyPlugin.cs
+++ b/KK_Pregnancy/PregnancyPlugin.cs
@@ -45,10 +45,10 @@ namespace KK_Pregnancy
             ConceptionEnabled = Config.Bind("General", "Enable conception", true,
                 "Allows characters to get pregnant from vaginal sex. Doesn't affect already pregnant characters.");
 
-            FertilityOverride = Config.Bind<float>("General", "Fertility override", 0.3f,
-                new ConfigDescription("Overrides default character fertility values with the one selected. \n\n" +
-                    "30%, 50%, 75%, 100% chance to get pregnant after HScene",
-                new AcceptableValueList<float>(0.3f, 0.5f, 0.75f, 1f)));
+            FertilityOverride = Config.Bind<float>("General", "Global fertility level", 0f,
+                new ConfigDescription("Sets a global fertility level that will be used when greater than the characters default fertility value. \n\n" +
+                    "30%, 50%, 75%, 100% chance to get pregnant after HScene\n 0% will revert to using characters default fertility value.",
+                new AcceptableValueList<float>(0f, 0.3f, 0.5f, 0.75f, 1f)));
 
             AnalConceptionEnabled = Config.Bind("General", "Enable anal conception", false,
                 "Allows characters to get pregnant from anal sex. Doesn't affect already pregnant characters.");

--- a/KK_Pregnancy/PregnancyPlugin.cs
+++ b/KK_Pregnancy/PregnancyPlugin.cs
@@ -19,7 +19,6 @@ namespace KK_Pregnancy
 
         public static ConfigEntry<bool> ConceptionEnabled { get; private set; }
         public static ConfigEntry<bool> AnalConceptionEnabled { get; private set; }
-        public static ConfigEntry<bool> ConceptionOverrideEnabled { get; private set; }
         public static ConfigEntry<bool> ShowPregnancyIconEarly { get; private set; }
         public static ConfigEntry<int> PregnancyProgressionSpeed { get; private set; }
         public static ConfigEntry<bool> HSceneMenstrIconOverride { get; private set; }
@@ -47,9 +46,6 @@ namespace KK_Pregnancy
 
             AnalConceptionEnabled = Config.Bind("General", "Enable anal conception", false,
                 "Allows characters to get pregnant from anal sex. Doesn't affect already pregnant characters.");
-
-            ConceptionOverrideEnabled = Config.Bind("General", "Override conception for all", false,
-                "Allows any character to get pregnant. Even if pregnancy has not been enabled in character creater.  Doesn't affect already pregnant characters.");
 
             ShowPregnancyIconEarly = Config.Bind("General", "Show pregnancy icon early", false,
                 "By default pregnancy status icon in class roster is shown after a few days or weeks (the character had a chance to do the test or noticed something is wrong).\n" +


### PR DESCRIPTION
Added two new config options for KK_Pregnancy

- ConceptionOverrideEnabled: flag to allow enabling conception globally for all characters.  (So you don't have to manually enable for each and every character card)

- InflationSpeed: for 1x, 2x, 3x belly inflation speeds.


If you want me to change anything let me know,
Thanks
