### PR TITLE
Suffer Crest should not increase the gauge if it is locked

### DIFF
--- a/KK_LewdCrestX/LewdCrestXGameController.cs
+++ b/KK_LewdCrestX/LewdCrestXGameController.cs
@@ -94,7 +94,7 @@ namespace KK_LewdCrestX
                     var heroineInfo = _hSceneHeroines[id];
                     heroineInfo.TotalRoughTime += Time.deltaTime;
 
-                    if (heroineInfo.CrestType == CrestType.suffer)
+                    if (heroineInfo.CrestType == CrestType.suffer && !_hSceneProc.flags.lockGugeFemale)
                         _hSceneProc.flags.gaugeFemale += speed * Time.deltaTime * 2;
                 }
             }


### PR DESCRIPTION
The current implementation increases the gauge even if the gauge is locked. I believe the locking mechanism should also lock everything.